### PR TITLE
Fix NullPointer on project creation

### DIFF
--- a/src/main/java/com/tcc/dynamicweb/service/ProjectService.java
+++ b/src/main/java/com/tcc/dynamicweb/service/ProjectService.java
@@ -95,14 +95,18 @@ public class ProjectService {
                                 project.setAdditionalInformation(additionalInformation);
                                 project.setProgrammingLanguague(programmingLanguage);
                                 Optional<Assistant> optionalAssistant = assistantRepository.findAssistantByThreadId(threadId);
+                                Assistant assistant;
 
-                                if (optionalAssistant.isEmpty()){
-                                    optionalAssistant.get().setType(CODE_GENERATOR);
+                                if (optionalAssistant.isPresent()) {
+                                    assistant = optionalAssistant.get();
+                                } else {
+                                    assistant = new Assistant();
+                                    assistant.setType(CODE_GENERATOR);
                                 }
-                                optionalAssistant.get().setThreadId(threadId);
 
-                                optionalAssistant.get().setProject(project);
-                                project.getAssistants().add(optionalAssistant.get());
+                                assistant.setThreadId(threadId);
+                                assistant.setProject(project);
+                                project.getAssistants().add(assistant);
                                 project.setPathToProject("C:\\Projects\\" + projectName);
 
                                 projectRepository.save(project);


### PR DESCRIPTION
## Summary
- prevent `Optional.get()` on empty optional when creating projects

## Testing
- `gradle test` *(fails: Plugin resolution requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_684ec9589b5083218f87102a53d681a3